### PR TITLE
Changing webpack.txt to latest updates.

### DIFF
--- a/webpack.txt
+++ b/webpack.txt
@@ -12,13 +12,13 @@ module.exports = {
     devtool: '#source-map',	
 		
 	module: {
-		loaders: [
+		rules: [
 			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|bower_components)/,
-				loader: 'babel',
+				loader: 'babel-loader',
 				query:{
-					presets:['react', 'es2015']
+					presets:['react', 'env']
 				}
 			}
 		]


### PR DESCRIPTION
Removes following bugs :
1.Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.module has an unknown property 'loaders'. 
2.Deprecated 'es2015' ( replaced with 'env')
3.Deprecated 'babel' ( replaced with 'babel-loader')